### PR TITLE
Items controller and views

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,10 @@
+class ItemsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def index
+  end
+end

--- a/app/views/items/create.html.erb
+++ b/app/views/items/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Items#create</h1>
-<p>Find me in app/views/items/create.html.erb</p>

--- a/app/views/items/create.html.erb
+++ b/app/views/items/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Items#create</h1>
+<p>Find me in app/views/items/create.html.erb</p>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Items#index</h1>
+<p>Find me in app/views/items/index.html.erb</p>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Items#new</h1>
+<p>Find me in app/views/items/new.html.erb</p>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,8 +1,17 @@
 <h1>YOU LANDED ON A POT OF JUNK</h1>
 
+<p>Temporary navigation links: </p>
+<ul>
+      <li><%= link_to "New item", items_new_path %></li>
+      <li><%= link_to "List items", items_index_path %></li>
+</ul>
+
+<br>
+
 <%= cl_image_tag("v1600366577/hf0tb75kupevvnu3tteo.jpg",
       width: 400, height: 300, crop: :fill) %>
 
 <!-- for face detection -->
 <%= cl_image_tag("v1600365538/BOB/IMG_0231_egncso.jpg",
       width: 150, height: 150, crop: :thumb, gravity: :face) %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'items/new'
+  get 'items/create'
+  get 'items/index'
   devise_for :users
   root to: 'pages#landing'
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ItemsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get items_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get items_create_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get items_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
Added temporary links on the landing page, to the newly created "new" and "index" pages for Items. 

![bilde](https://user-images.githubusercontent.com/63665667/93663107-8cda9e80-fa65-11ea-80b9-ea75f2e2a2a4.png)
